### PR TITLE
fix email link

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ layout: default
         {% endif %}
 
         {% if site.contact_email %}
-        <a class='contact-icon' href="mailto:{{ site.slack_link }}" target="_new">
+        <a class='contact-icon' href="mailto:{{ site.email }}" target="_new">
           <i class="fa fa-envelope fa-2x"></i>
         </a>
 


### PR DESCRIPTION
Email link was incorrectly pointing to slack url.

(Also, there are two email fields in `_config.yml`: `email` and `contact_email`. Both have the same value.) 
